### PR TITLE
Update verify.ts

### DIFF
--- a/packages/amplify-cli/src/commands/plugin/verify.ts
+++ b/packages/amplify-cli/src/commands/plugin/verify.ts
@@ -8,7 +8,7 @@ export async function run(context: Context) {
     context.print.success('The current directory is verified to be a valid Amplify CLI plugin package.');
     context.print.info('');
   } else {
-    context.print.error('The current directory faied Amplify CLI plugin verification.');
+    context.print.error('The current directory failed Amplify CLI plugin verification.');
     context.print.info(`Error code: ${verificatonResult.error}`);
     context.print.info('');
   }


### PR DESCRIPTION
Fix typo

*Issue #, if available:*
When running amplify plugin verify, I have the following message:

The current directory **faied** Amplify CLI plugin verification

*Description of changes:*

Fix typo error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.